### PR TITLE
Fix issue#1, fix can not open "select tag dialog" when not start serv…

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,8 +3,8 @@ import folder_paths
 import shutil
 cwd = os.getcwd()
 
-select_tags_path = os.path.join(cwd, "ComfyUI", "web", "extensions", "select_tags")
-select_tags_path_bk = os.path.join(cwd, "ComfyUI", "custom_nodes", "comfy_assemble_tags_node", "select_tags")
+select_tags_path = os.path.join(cwd, "web", "extensions", "select_tags")
+select_tags_path_bk = os.path.join(cwd, "custom_nodes", "comfy_assemble_tags_node", "select_tags")
 
 if not os.path.isdir(select_tags_path):
     print("----------start------第一次使用-------未发现select_tags文件夹，正在处理。。。")

--- a/select_tags/select_tags.js
+++ b/select_tags/select_tags.js
@@ -73,7 +73,7 @@ app.registerExtension({
 					if (!XLSXDATA || Object.keys(XLSXDATA).length < 1) {
 						// 我不想每次都请求这个，但是为了正确地获得这个文件的最新内容，我必须禁用浏览器缓存，要不然去修改了这个表后由于浏览器缓存，无法刷新最新数据出来
 						// I don't want to request this every time, but in order to get the latest contents of this file correctly I have to disable the browser cache
-						fetch('http://127.0.0.1:8188/extensions/select_tags/tags.xlsx', {
+						fetch('/extensions/select_tags/tags.xlsx', {
 							cache: 'reload'
 						  })
 						.then(response => response.arrayBuffer())


### PR DESCRIPTION
Normal start server at directory "ComfyUI", so needn't combine "ComfyUI" to path.
If server start with parameter "--listen", and visit from remote pc, load from "http://127.0.0.1..." will failed.